### PR TITLE
Fixed plapt_cli.py to apply score_candidates and predict_affinity

### DIFF
--- a/plapt_cli.py
+++ b/plapt_cli.py
@@ -36,7 +36,10 @@ def main():
     args = parser.parse_args()
 
     plapt = Plapt()
-    results = plapt.predict_affinity(args.target[0], args.smiles)
+    if len(args.target) == len(args.smiles):
+        results = plapt.predict_affinity(args.target, args.smiles)
+    else:
+        results = plapt.score_candidates(args.target, args.smiles)
 
     args.output, output_format = determine_format_and_update_filename(args.output, args.format)
 


### PR DESCRIPTION
Previously, [`plapt_cli.py`](https://github.com/Bindwell/PLAPT/blob/ebc63918773734d23707d4a220b239c36a942630/plapt_cli.py) only called the `predict_affinity` function, which seems to be for scoring protein-ligand pairs only (according to [`README.md`](https://github.com/Bindwell/PLAPT/blob/ebc63918773734d23707d4a220b239c36a942630/README.md)). It was also passing the first target sequence only (`args.target[0]`) in `predict_affinity`, which raises a `ValueError` when the function checks for the length of the input targets and input molecules.

[`plapt_cli.py`](https://github.com/csecker/PLAPT/blob/a870acc6c9f65d319710d2ed05302b6543e135cb/plapt_cli.py) now uses `predict_affinity` for scoring protein-ligand pairs, if there are the same number of targets and molecules. If there are more or less molecules than targets, `score_candidates` is used (scoring all molecules on the first target provided).